### PR TITLE
Chapter 4 errata

### DIFF
--- a/errata/04_machine_learning_basics_errata.md
+++ b/errata/04_machine_learning_basics_errata.md
@@ -1,0 +1,19 @@
+# Errata - Chapter 4: Machine Learning Basics
+
+**Full book page no.
+
+* **p.111** "If you encode the symbols assuming any other probability for the q_i than the real p_i need more bits for encoding each symbol.". Should read as "...than the real p_i, you need more..." - _Found 7/22/2016_
+
+* **p.114** "You can proof that if...". Should read as "You can prove that if..." - _Found 7/22/2016_
+
+* **p.115** "b = tf.Variable(tf.zeros([3], name="bias"))". Should read as "b = tf.Variable(tf.zeros([3]), name="bias")" - _Found 7/22/2016_
+
+* **p.117** "predicted = tf.cast(tf.arg_max(inference(X), 1), tf.int32)" and then "We use the tf.argmax function to choose...". The code part should read "tf.argmax" for consistency with the rest of the code so far, as well as it being visible in the TensorFlow documentation - _Found 7/22/2016_
+
+* **p.120** "We can’t find a single stright line that would split the chart..." Should say "straight" - _Found 7/22/2016_
+
+* **p.121** "Then you can leave all of the equal outputs grouped toghether in a single area." Should say "together" - _Found 7/22/2016_
+
+* **p.128** "Tensorflow includes the method tf.gradients to simbolically computate the gradients..." Should say "symbolically compute" - _Found 7/22/2016_
+
+* **p.129** "loss = cross<sub>e</sub>ntropy L3, y_expected)" Should read as "cross_entropy" - _Found 7/22/2016_


### PR DESCRIPTION
I finished going over chapter 4 today and here's what I found. I also found some other stuff that I wasn't entirely sure about, so I'll make a note of it here and let someone else decide what to do:
- Softmax prediction section:
  Because we're reusing read_csv() from the logistic regression section, read_csv() still has skip_header_lines=1 even though there is no header in the iris data. This results in 96% instead of the stated 95% in the book during my runs. Removing that option results in 95% as stated.
- Page 120:
  "This problem actually made neural network research to loss importance for about a decade around 1970’s."
  I feel like there are a few problems in this line but I might just not be understanding it.
- Page 121: 
  "You can think of it as allowing our network to ask multiple questions to the input data, one question per neuron on the hidden layer. And finally decide the output result based on the answers of those questions."
  Is the "And" sentence starting its own sentence intentional?
- Page 130:
  ∂loss / ∂w<sub>2</sub> = loss′ . L3′ . L2′ . L1′ . x
  Should this really be ∂w<sub>2</sub> here? I'm not confident enough in my math to say for sure.
