### PR TITLE
Update serving example to build with current TF Serving

### DIFF
--- a/chapters/07_production/BUILD
+++ b/chapters/07_production/BUILD
@@ -4,7 +4,7 @@ py_binary(
         "export.py",
     ],
     deps = [
-        "@tf_serving//tensorflow_serving/session_bundle:exporter",
+        "@org_tensorflow//tensorflow/contrib/session_bundle:exporter",
         "@org_tensorflow//tensorflow:tensorflow_py",
         # only needed for inception model export
         "@inception_model//inception",

--- a/chapters/07_production/WORKSPACE
+++ b/chapters/07_production/WORKSPACE
@@ -2,20 +2,20 @@ workspace(name = "serving")
 
 local_repository(
     name = "tf_serving",
-    path = __workspace_dir__ + "/tf_serving",
+    path = "tf_serving",
 )
 
 local_repository(
     name = "org_tensorflow",
-    path = __workspace_dir__ + "/tf_serving/tensorflow",
+    path = "tf_serving/tensorflow",
 )
 
-load('//tf_serving/tensorflow/tensorflow:workspace.bzl', 'tf_workspace')
-tf_workspace("tf_serving/tensorflow/", "@org_tensorflow")
+load('@org_tensorflow//tensorflow:workspace.bzl', 'tf_workspace')
+tf_workspace()
 
 bind(
     name = "libssl",
-    actual = "@boringssl_git//:ssl",
+    actual = "@boringssl//:ssl",
 )
 
 bind(
@@ -27,5 +27,5 @@ bind(
 
 local_repository(
     name = "inception_model",
-    path = __workspace_dir__ + "/tf_serving/tf_models/inception",
+    path = "tf_serving/tf_models/inception",
 )

--- a/chapters/07_production/export.py
+++ b/chapters/07_production/export.py
@@ -10,7 +10,7 @@ import time
 import sys
 
 import tensorflow as tf
-from tensorflow_serving.session_bundle import exporter
+from tensorflow.contrib.session_bundle import exporter
 from inception import inception_model
 
 NUM_CLASSES_TO_RETURN = 10
@@ -43,7 +43,7 @@ with tf.Session() as sess:
     # Restore variables from training checkpoints.
     ckpt = tf.train.get_checkpoint_state(sys.argv[1])
     if ckpt and ckpt.model_checkpoint_path:
-        saver.restore(sess, sys.argv[1] + "/" + ckpt.model_checkpoint_path)
+        saver.restore(sess, ckpt.model_checkpoint_path)
     else:
         print("Checkpoint file not found")
         raise SystemExit


### PR DESCRIPTION
I needed to update a few things in order to build serving example with current Tensorflow Serving version. It worked fine for me with commit `ace1b2904a3d4ec6b487f48617051b02173619bc` of TF Serving and provided docker image.

I also needed to `-c opt` to bazel build commands.
